### PR TITLE
make disk detection more robust in upgrade and system scripts

### DIFF
--- a/BSDRP/Files/usr/local/sbin/system
+++ b/BSDRP/Files/usr/local/sbin/system
@@ -146,7 +146,7 @@ expand_data_slice () {
 		die "Not supported: sparc64 for this function"
 	else
 		boot_dev=/dev/`glabel status | grep ${NANO_DRIVE}s1a \
-			 | awk '{ print $3; }' | cut -d s -f 1`
+			 | awk '{ s=$3; sub(/s[12]a$/, "", s); print s; }'`
 	fi
 	label=`cut -d '/' -f 2 /etc/nanobsd.conf`
 

--- a/BSDRP/Files/usr/local/sbin/upgrade
+++ b/BSDRP/Files/usr/local/sbin/upgrade
@@ -69,9 +69,8 @@ mbr_get_info() {
 	BSD_SLICE="a"
 
 	# ufs/BSDRPs1a     N/A  aacd0s1a
-	boot_dev=/dev/`glabel status | grep ${SRC_LABEL} | awk '{ print $3; }'\
-       	| cut -d s -f 1`
-
+	boot_dev=/dev/`glabel status | grep ${SRC_LABEL} | \
+		awk '{ s=$3; sub(/s[12]a$/, "", s); print s; }'`
 }
 
 # Get label information for Sun VTOC


### PR DESCRIPTION
A Dell  host with PERC controller identifies its disk as mfisyspd0.
This causes the upgrade and system scripts to fail because they
look for 's' in order to separate the disk identifier from the slices.

This patch contains a better awk command line that should work
more generally.
