### PR TITLE
Adapt to new vmstat output in FreeBSD 11

### DIFF
--- a/BSDRP/Files/usr/local/etc/rc.d/ix_affinity
+++ b/BSDRP/Files/usr/local/etc/rc.d/ix_affinity
@@ -44,7 +44,7 @@ ix_affinity_start()
 	ix=$(sysctl dev.ix. | grep -c irqs)
 	for i in $(seq 1 ${ix}); do
 		for IRQ in `/usr/bin/vmstat -ai |\
-	    	/usr/bin/sed -nE '/ix${i}:que./ s/irq([[:digit:]]+):.*/\1/p'`; do
+	    	/usr/bin/sed -nE '/ix${i}:q./ s/irq([[:digit:]]+):.*/\1/p'`; do
 			echo "Bind ix${i} IRQ ${IRQ} to CPU ${CPU}"
 			/usr/bin/cpuset -l ${CPU} -x ${IRQ}
 			CPU=$(((CPU + 1) % NCPU))


### PR DESCRIPTION
In FreeBSD 11 the `vmstat -ai` output now displays `ix1:q0` instead of `ix1:que0`. The rc script is now updated to match the correct string pattern.