### PR TITLE
add BGPQ3 port

### DIFF
--- a/BSDRP/BSDRP.nano
+++ b/BSDRP/BSDRP.nano
@@ -507,6 +507,9 @@ add_port "sysutils/devcpu-data"
 # NANOG traceroute : MPLS label decode, Path MTU discovery, AS lookup, spray mode
 add_port "net/ntraceroute"
 
+# BGPQ3: Lightweight prefix-list generator for Cisco and Juniper routers
+add_port "net-mgmt/bgpq3"
+
 #### End of port list section ####
 
 # Add netrate tools


### PR DESCRIPTION
BGPQ3 is a small tool for generating prefix filter lists. As it supports also BIRD and FRR, it makes sense to have it in BSDRP, so one can generate filter lists directly on the router.