### PR TITLE
add support for vxlan

### DIFF
--- a/BSDRP/kernels/amd64
+++ b/BSDRP/kernels/amd64
@@ -289,6 +289,7 @@ device		tun			# Packet tunnel.
 device		md			# Memory "disks"
 device		gif			# IPv6 and IPv4 tunneling
 device		firmware		# firmware assist module
+device		vxlan			# vxlan tunneling
 
 # The `bpf' device enables the Berkeley Packet Filter.
 # Be aware of the administrative consequences of enabling this!

--- a/BSDRP/kernels/i386
+++ b/BSDRP/kernels/i386
@@ -303,6 +303,7 @@ device		tun			# Packet tunnel.
 device		md			# Memory "disks"
 device		gif			# IPv6 and IPv4 tunneling
 device		firmware		# firmware assist module
+device		vxlan			# vxlan tunneling
 
 # The `bpf' device enables the Berkeley Packet Filter.
 # Be aware of the administrative consequences of enabling this!

--- a/BSDRPcur/kernels/amd64
+++ b/BSDRPcur/kernels/amd64
@@ -323,6 +323,7 @@ device		tun			# Packet tunnel.
 device		md			# Memory "disks"
 device		gif			# IPv6 and IPv4 tunneling
 device		firmware		# firmware assist module
+device		vxlan			# vxlan tunneling
 
 # The `bpf' device enables the Berkeley Packet Filter.
 # Be aware of the administrative consequences of enabling this!

--- a/BSDRPcur/kernels/i386
+++ b/BSDRPcur/kernels/i386
@@ -323,6 +323,7 @@ device		tun			# Packet tunnel.
 device		md			# Memory "disks"
 device		gif			# IPv6 and IPv4 tunneling
 device		firmware		# firmware assist module
+device		vxlan			# vxlan tunneling
 
 # The `bpf' device enables the Berkeley Packet Filter.
 # Be aware of the administrative consequences of enabling this!

--- a/BSDRPcur/kernels/sparc64
+++ b/BSDRPcur/kernels/sparc64
@@ -179,6 +179,7 @@ device		md		# Memory "disks"
 device		gif		# IPv6 and IPv4 tunneling
 device		faith		# IPv6-to-IPv4 relaying (translation)
 device		firmware	# firmware assist module
+device		vxlan		# vxlan tunneling
 
 # The `bpf' device enables the Berkeley Packet Filter.
 # Be aware of the administrative consequences of enabling this!

--- a/BSDRPstable/kernels/amd64
+++ b/BSDRPstable/kernels/amd64
@@ -289,6 +289,7 @@ device		tun			# Packet tunnel.
 device		md			# Memory "disks"
 device		gif			# IPv6 and IPv4 tunneling
 device		firmware		# firmware assist module
+device		vxlan			# vxlan tunneling
 
 # The `bpf' device enables the Berkeley Packet Filter.
 # Be aware of the administrative consequences of enabling this!

--- a/BSDRPstable/kernels/i386
+++ b/BSDRPstable/kernels/i386
@@ -302,6 +302,7 @@ device		tun			# Packet tunnel.
 device		md			# Memory "disks"
 device		gif			# IPv6 and IPv4 tunneling
 device		firmware		# firmware assist module
+device		vxlan			# vxlan tunneling
 
 # The `bpf' device enables the Berkeley Packet Filter.
 # Be aware of the administrative consequences of enabling this!

--- a/EINE/kernels/amd64
+++ b/EINE/kernels/amd64
@@ -284,6 +284,7 @@ device		tun			# Packet tunnel.
 device		md			# Memory "disks"
 device		gif			# IPv6 and IPv4 tunneling
 device		firmware		# firmware assist module
+device		vxlan			# vxlan tunneling
 
 # The `bpf' device enables the Berkeley Packet Filter.
 # Be aware of the administrative consequences of enabling this!


### PR DESCRIPTION
When I try to create a vxlan interface with:
``ifconfig vxlan create vxlanid 42 vxlanlocal 5.9.226.90 vxlanremote 185.243.23.253 inet 185.243.20.193/31``
I get `ifconfig: SIOCIFCREATE2: Invalid argument`
Also a `kldload vxlan` results in `kldload: can't load vxlan: No such file or directory`, so I added the vxlan device in the kernel configs