### PR TITLE
fix: replace hardcoded ada0 with boot_dev in expand_data_slice()

### DIFF
--- a/BSDRP/Files/usr/local/sbin/system
+++ b/BSDRP/Files/usr/local/sbin/system
@@ -255,7 +255,7 @@ expand_data_slice () {
 	gpart recover /dev/${boot_dev}
 
 	#free space
-	free_space=$(gpart show ada0 | awk '/- free -/ {gsub(/[()]/, "", $6); print $6}')
+	free_space=$(gpart show ${boot_dev} | awk '/- free -/ {gsub(/[()]/, "", $6); print $6}')
 	[ -z "${free_space}" ] && die "There is no space left on disk"
 	echo "There is ${free_space} available on your disk that can be use for /data"
 	user_confirm "Are you sure to repartition your disk (it is a long process) ? (y/n)"


### PR DESCRIPTION
expand_data_slice() correctly resolves the boot device via label2dev() into $boot_dev, but then hardcodes 'ada0' in the gpart show call. This fails on systems where the boot disk is not ada0 (e.g. da0).

Tested on Dell R630 with a virtual disk da0 descr: DELL PERC H730 Mini