### PR TITLE
fix: remove retired le(4) driver from amd64 kernel config

### DIFF
--- a/BSDRP/kernels/amd64
+++ b/BSDRP/kernels/amd64
@@ -241,7 +241,6 @@ device		axp			# AMD EPYC integrated NIC (requires miibus)
 
 # PCI Ethernet NICs.
 device		bxe			# Broadcom NetXtreme II BCM5771X/BCM578XX 10GbE
-device		le			# AMD Am7900 LANCE and Am79C9xx PCnet
 device		rge			# Realtek 8125/8126/8127
 device		ti			# Alteon Networks Tigon I/II gigabit Ethernet
 


### PR DESCRIPTION
le(4) was retired from FreeBSD (commit 7a323f873662). Building with device le causes:
  cc: error: no such file or directory: 'sys/dev/le/am7990.c'

Tested on FreeBSD 16.0-CURRENT at commit 5b7aa6c7bc9.