### PR TITLE
fix: unquote DEBUG_PROPAGATE in post-upgrade script call

### DIFF
--- a/BSDRP/Files/usr/local/sbin/upgrade
+++ b/BSDRP/Files/usr/local/sbin/upgrade
@@ -356,7 +356,7 @@ if [ -f /tmp/post-upgrade ]; then
 	logger Starting post-upgrade script
 
 	# Execute post-upgrade script with new partition as parameter
-	sh "$DEBUG_PROPAGATE" /tmp/post-upgrade /dev/${NANO_DRIVE}${NEXT_LABEL_ID}
+	sh ${DEBUG_PROPAGATE} /tmp/post-upgrade /dev/${NANO_DRIVE}${NEXT_LABEL_ID}
 fi
 
 [ -f ${LOCK} ] && rm ${LOCK}


### PR DESCRIPTION
When DEBUG_PROPAGATE is empty, 'sh "$DEBUG_PROPAGATE"' passes an empty string as the script name causing:
  sh: cannot open : No such file or directory

Unquoting the variable causes it to expand to nothing when empty, fixing the post-upgrade script execution.

Tested during PRTR upgrade from 2.0.0-dev to 2.1.0-dev.