### PR TITLE
Fix/tenant improvements

### DIFF
--- a/BSDRP/Files/usr/local/sbin/tenant
+++ b/BSDRP/Files/usr/local/sbin/tenant
@@ -168,7 +168,7 @@ create () {
 		if [ -f /etc/jail.conf ]; then
 			grep -E -q "vnet\.interface.*${nicname}" /etc/jail.conf && die "Interface ${nicname} already declared into /etc/jail"
 		else
-			grep -Esq "vnet.\interface.%${nicname}" /etc/jail.conf.d/*.conf && die "Interface ${nicname} already declared into /etc/jail.conf.d/*.conf"
+			grep -E -qs "vnet\.interface.*${nicname}" /etc/jail.conf.d/*.conf && die "Interface ${nicname} already declared into /etc/jail.conf.d/*.conf"
 		fi
 		[ "$nicslist" = "$iter" ] && nicslist='' || nicslist="${nicslist#*,}"
 	done

--- a/BSDRP/Files/usr/local/sbin/tenant
+++ b/BSDRP/Files/usr/local/sbin/tenant
@@ -63,6 +63,29 @@ fi
 # A useful function (from: http://code.google.com/p/sh-die/)
 die() { echo -n "EXIT: " >&2; echo "$@" >&2; exit 1; }
 
+# Cleanup partial jail creation on failure.
+# Only removes artifacts for the jail being created.
+# Never touches other configured or running jails.
+CLEANUP_NEEDED=false
+cleanup_on_failure() {
+	if $CLEANUP_NEEDED && [ -n "${tenant}" ]; then
+		echo "WARNING: cleaning up partial jail '${tenant}'..." >&2
+		jls -j "${tenant}" > /dev/null 2>&1 && \
+			service jail stop "${tenant}" > /dev/null 2>&1 || true
+		mount | grep -q "${jailbase}/${tenant}/dev" && \
+			umount -f "${jailbase}/${tenant}/dev" > /dev/null 2>&1 || true
+		[ -f "/etc/jail.conf.d/${tenant}.fstab" ] && \
+			umount -a -F "/etc/jail.conf.d/${tenant}.fstab" > /dev/null 2>&1 || true
+		rm -f "/etc/jail.conf.d/${tenant}.conf"
+		rm -f "/etc/jail.conf.d/${tenant}.fstab"
+		[ -d "${jailbase}/${tenant}" ] && rm -rf "${jailbase}/${tenant}" || true
+		[ -d "/etc/jails/${tenant}" ] && rm -rf "/etc/jails/${tenant}" || true
+		sysrc -q jail_list-="${tenant}" > /dev/null 2>&1 || true
+	fi
+}
+trap cleanup_on_failure EXIT
+
+
 # Derive next jail ID from existing /etc/jail.conf.d/*.conf files.
 # Falls back to /etc/jail.lastid for backward compatibility.
 # Returns 1 if no jails exist.
@@ -132,6 +155,7 @@ create () {
 
 	jailroot="${jailbase}/${tenant}"
 	jailfstab="/etc/jail.conf.d/${tenant}.fstab"
+	CLEANUP_NEEDED=true
 	mkdir -p ${jailroot}
 
 	if ( $NANOBSD ); then
@@ -397,6 +421,7 @@ EOF
 	sysrc -q jail_parallel_start="YES" > /dev/null 2>&1
 	sysrc -q jail_list+=${tenant} > /dev/null 2>&1
 
+	CLEANUP_NEEDED=false
 	echo "Jail is created, you can start it now (service jail start ${tenant})"
 	exit 0
 }

--- a/BSDRP/Files/usr/local/sbin/tenant
+++ b/BSDRP/Files/usr/local/sbin/tenant
@@ -462,19 +462,16 @@ delete () {
 		jaildir=$(grep 'path.*=.*;' /etc/jail.conf.d/${tenant}.conf | cut -d '"' -f 2)
 		if ! [ -d "${jaildir}" ]; then
 			die "ERROR: No directory ${jaildir} extracted from path in /etc/jail.conf.d/${tenant}.conf"
-		else
-			echo "XXX: Extracted jaildir: ${jaildir}"
 		fi
 	fi
 	if [ -f /etc/jail.conf ]; then
 		grep -q "^${tenant} {" /etc/jail.conf || die "ERROR: No jail named $tenant configured in /etc/jail.conf"
-		die "XXX: Need to extract jaildir here (or to be set on command line)"
 	fi
 	if ! [ -d ${jailbase}/${tenant} ]; then
 		die "No directory ${jailbase}/${tenant} found (need to specify -b basedir if used during creation)"
 	fi
 	jls -j ${tenant} > /dev/null 2>&1 && die "Jail is running: Stop it before delete it (service jail stop ${tenant})"
-	mount | grep -q "/var/jails/${tenant}/" && die "There are still some mount points regarding ${tenant}"
+	mount | grep -q "${jailbase}/${tenant}/" && die "There are still some mount points regarding ${tenant}"
 	rm -f /etc/fstab.${tenant}
 	rm -f /etc/jail.conf.d/${tenant}.fstab
 	rm -f /etc/jail.conf.d/${tenant}.conf

--- a/BSDRP/Files/usr/local/sbin/tenant
+++ b/BSDRP/Files/usr/local/sbin/tenant
@@ -42,6 +42,7 @@ root_dir_size=""
 root_tmpfs=false
 create=false
 delete=false
+list=false
 tenant=""
 nics=""
 defaultgw=""
@@ -106,11 +107,33 @@ get_next_id() {
 	echo $((maxid + 1))
 }
 
+# List all configured jails and their running status
+list_jails () {
+	echo "Configured jails:"
+	local found=false
+	for conf in /etc/jail.conf.d/*.conf; do
+		[ -f "$conf" ] || continue
+		found=true
+		name=$(basename "$conf" .conf)
+		jid=$(grep -E '^[[:space:]]+jid[[:space:]]*=' "$conf" 2>/dev/null \
+			| grep -o '[0-9]*' | head -1)
+		if jls -j "$name" > /dev/null 2>&1; then
+			state="RUNNING"
+		else
+			state="STOPPED"
+		fi
+		printf "  %-20s jid=%-4s %s\n" "$name" "${jid:-?}" "$state"
+	done
+	$found || echo "  (none configured)"
+	exit 0
+}
+
 # Display usage
 usage () {
 	echo "Usage: $0 -c|-d -j name -f authorized_keys -i if/ip/mask"
 	echo "  -c: create a jail"
 	echo "  -d: delete a jail"
+	echo "  -l: list configured jails and their status"
 	echo "  -b: base directory to store jails (default: ${jailbase})"
 	echo "  -f authorized_keys: SSH authorized_keys to be installed into jail"
 	echo "  -g default-gateway: Default gateway"
@@ -486,7 +509,7 @@ if [ $# -le 0 ] ; then
     usage
 fi
 
-args=$(getopt b:cdf:g:hi:j:t:v:V $*)
+args=$(getopt b:cdf:g:hi:j:lt:v:V $*)
 
 set -- $args
 for i; do
@@ -533,6 +556,10 @@ for i; do
 		shift
 		shift
 		;;
+	-l)
+		list=true
+		shift
+		;;
 	-t)
 		root_tmpfs=true
 		root_dir_size=$2
@@ -555,6 +582,7 @@ for i; do
 	esac
 done
 
+($list) && list_jails
 [ -z "$tenant" ] && die "jail name mandatory"
 ($create) && create
 ($delete) && delete

--- a/BSDRP/Files/usr/local/sbin/tenant
+++ b/BSDRP/Files/usr/local/sbin/tenant
@@ -461,22 +461,23 @@ delete () {
 	else
 		jaildir=$(grep 'path.*=.*;' /etc/jail.conf.d/${tenant}.conf | cut -d '"' -f 2)
 		if ! [ -d "${jaildir}" ]; then
-			die "ERROR: No directory ${jaildir} extracted from path in /etc/jail.conf.d/${tenant}.conf"
+			echo "WARNING: Directory ${jaildir} already missing — cleaning up orphan configs anyway" >&2
 		fi
 	fi
 	if [ -f /etc/jail.conf ]; then
 		grep -q "^${tenant} {" /etc/jail.conf || die "ERROR: No jail named $tenant configured in /etc/jail.conf"
 	fi
 	if ! [ -d ${jailbase}/${tenant} ]; then
-		die "No directory ${jailbase}/${tenant} found (need to specify -b basedir if used during creation)"
+		echo "WARNING: Directory ${jailbase}/${tenant} already missing — cleaning up orphan configs anyway" >&2
 	fi
 	jls -j ${tenant} > /dev/null 2>&1 && die "Jail is running: Stop it before delete it (service jail stop ${tenant})"
 	mount | grep -q "${jailbase}/${tenant}/" && die "There are still some mount points regarding ${tenant}"
 	rm -f /etc/fstab.${tenant}
 	rm -f /etc/jail.conf.d/${tenant}.fstab
 	rm -f /etc/jail.conf.d/${tenant}.conf
-	chflags -R noschg ${jailbase}/${tenant}
+	[ -d "${jailbase}/${tenant}" ] && chflags -R noschg ${jailbase}/${tenant}
 	rm -rf ${jailbase}/${tenant}
+	[ -d /etc/jails/${tenant} ] && rm -rf /etc/jails/${tenant}
 	if [ -f /etc/jail.conf ]; then
 		sed -i "" -e "/^$tenant {/,/^}/d" /etc/jail.conf
 	fi

--- a/BSDRP/Files/usr/local/sbin/tenant
+++ b/BSDRP/Files/usr/local/sbin/tenant
@@ -63,6 +63,26 @@ fi
 # A useful function (from: http://code.google.com/p/sh-die/)
 die() { echo -n "EXIT: " >&2; echo "$@" >&2; exit 1; }
 
+# Derive next jail ID from existing /etc/jail.conf.d/*.conf files.
+# Falls back to /etc/jail.lastid for backward compatibility.
+# Returns 1 if no jails exist.
+get_next_id() {
+	local maxid=0
+	local jid
+	for conf in /etc/jail.conf.d/*.conf; do
+		[ -f "$conf" ] || continue
+		jid=$(grep -E '^[[:space:]]+jid[[:space:]]*=' "$conf" 2>/dev/null \
+			| grep -o '[0-9]*' | head -1)
+		[ -n "$jid" ] && [ "$jid" -gt "$maxid" ] && maxid=$jid
+	done
+	# Fall back to legacy jail.lastid if higher
+	if [ -f /etc/jail.lastid ]; then
+		. /etc/jail.lastid
+		[ "$id" -gt "$maxid" ] && maxid=$id
+	fi
+	echo $((maxid + 1))
+}
+
 # Display usage
 usage () {
 	echo "Usage: $0 -c|-d -j name -f authorized_keys -i if/ip/mask"
@@ -107,13 +127,8 @@ create () {
 		[ "$nicslist" = "$iter" ] && nicslist='' || nicslist="${nicslist#*,}"
 	done
 
-	# Get last ID
-	if [ -f /etc/jail.lastid ]; then
-		. /etc/jail.lastid
-		id=$(( id + 1))
-	else
-		id=1
-	fi
+	# Derive next jail ID from existing configs
+	id=$(get_next_id)
 
 	jailroot="${jailbase}/${tenant}"
 	jailfstab="/etc/jail.conf.d/${tenant}.fstab"
@@ -377,11 +392,6 @@ EOF
     exec.poststop  += "logger jail ${tenant} post-stopped";
 }
 EOF
-	{
-		echo "#!/bin/sh"
-		echo "id=$id"
-	} > /etc/jail.lastid
-
 	# Now enable this jail
 	sysrc -q jail_enable="YES" > /dev/null 2>&1
 	sysrc -q jail_parallel_start="YES" > /dev/null 2>&1
@@ -432,12 +442,12 @@ delete () {
 	if [ -f /etc/jail.conf ]; then
 		if ! grep -q '{' /etc/jail.conf; then
 			rm /etc/jail.conf || die "ERROR during deleting /etc/jail.conf"
-			rm /etc/jail.lastid || die "ERROR during deleting /etc/jail.lastid"
+			[ -f /etc/jail.lastid ] && rm /etc/jail.lastid
 			sysrc -q jail_enable="NO"  > /dev/null 2>&1
 		fi
 	elif [ -d /etc/jail.conf.d ]; then
 		if [ -z "$(ls -A /etc/jail.conf.d 2>/dev/null)" ]; then
-			rm /etc/jail.lastid || die "ERROR during deleting /etc/jail.lastid"
+			[ -f /etc/jail.lastid ] && rm /etc/jail.lastid
 			sysrc -q jail_enable="NO"  > /dev/null 2>&1
 		fi
 	fi


### PR DESCRIPTION
This PR contains 6 focused, independent changes to tenant.
Each is committed separately for easier review.

1. fix: derive next jail ID from configs, avoid jail.lastid SPOF
2. fix: add trap-based cleanup on partial jail creation failure
3. feat: add -l flag to list configured jails
4. fix: clean up delete() function
5. fix: correct broken grep pattern for interface duplicate check
6. fix: make delete() recover from orphan configs gracefully

All upstream features (-t, -v, -V, -b flags, MAC generation, fstab
structure, jail.conf migration path, etc.) are preserved unchanged.

Tested through a full lifecycle on a 3-jail production FreeBSD
router: create, start, stop, delete, plus failure recovery
scenarios. No orphan state remains after delete; failed creations
are auto-cleaned.