### PR TITLE
fix: validate NANO_DRIVE after sourcing /etc/nanobsd.conf

### DIFF
--- a/BSDRP/Files/usr/local/sbin/upgrade
+++ b/BSDRP/Files/usr/local/sbin/upgrade
@@ -71,6 +71,10 @@ esac
 [ -f /etc/nanobsd.conf ] || die "No /etc/nanobsd.conf found"
 . /etc/nanobsd.conf
 
+# Defensive: a corrupt or empty /etc/nanobsd.conf would leave NANO_DRIVE
+# unset, tripping set -u below.
+[ -n "${NANO_DRIVE:-}" ] || die "NANO_DRIVE not set in /etc/nanobsd.conf"
+
 #Extract LABEL name
 LABEL=${NANO_DRIVE##*/}
 


### PR DESCRIPTION
The upgrade script sources /etc/nanobsd.conf and immediately uses NANO_DRIVE without checking it was actually set. A corrupt, truncated or empty config file would leave NANO_DRIVE unset, tripping set -u later in the script with a less informative error.

Applies the same defensive pattern used in tenant's get_next_id() for sourcing legacy /etc/jail.lastid: use ${var:-} fallback when checking, fail early with a clear error message.

Low practical risk on a healthy system since /etc/nanobsd.conf is generated by the build process, but defensive enough to catch the case where the file was tampered with or partially written during recovery operations.